### PR TITLE
Implementación de test unitarios para la clase Checker

### DIFF
--- a/backgammon/tests/test_checker.py
+++ b/backgammon/tests/test_checker.py
@@ -1,0 +1,67 @@
+import unittest
+from backgammon.core.checker import Checker
+
+class TestChecker(unittest.TestCase):
+    
+    def test_initialization(self):
+        white_checker = Checker(0)
+        black_checker = Checker(1)
+        
+        self.assertEqual(white_checker.get_player_id(), 0)
+        self.assertEqual(black_checker.get_player_id(), 1)
+        
+        self.assertFalse(white_checker.is_captured())
+        self.assertFalse(white_checker.is_bearing_off())
+        self.assertFalse(black_checker.is_captured())
+        self.assertFalse(black_checker.is_bearing_off())
+    
+    def test_capture(self):
+        checker = Checker(0)
+        
+        self.assertFalse(checker.is_captured())
+        
+        checker.set_captured(True)
+        self.assertTrue(checker.is_captured())
+        
+        checker.set_captured(False)
+        self.assertFalse(checker.is_captured())
+    
+    def test_bearing_off(self):
+        checker = Checker(1)
+        
+        self.assertFalse(checker.is_bearing_off())
+        
+        checker.set_bearing_off(True)
+        self.assertTrue(checker.is_bearing_off())
+        
+        checker.set_bearing_off(False)
+        self.assertFalse(checker.is_bearing_off())
+    
+    def test_player_id_immutability(self):
+        checker = Checker(0)
+        self.assertEqual(checker.get_player_id(), 0)
+        
+        checker.set_captured(True)
+        checker.set_bearing_off(True)
+        self.assertEqual(checker.get_player_id(), 0)
+    
+    def test_state_transitions(self):
+        checker = Checker(0)
+        
+        self.assertFalse(checker.is_captured())
+        self.assertFalse(checker.is_bearing_off())
+        
+        checker.set_captured(True)
+        self.assertTrue(checker.is_captured())
+        self.assertFalse(checker.is_bearing_off())
+        
+        checker.set_captured(False)
+        self.assertFalse(checker.is_captured())
+        self.assertFalse(checker.is_bearing_off())
+        
+        checker.set_bearing_off(True)
+        self.assertFalse(checker.is_captured())
+        self.assertTrue(checker.is_bearing_off())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #12
En este PR implementé tests unitarios completos para la clase Checker. 
Aunque revisando el material del curso no vi un requisito explícito para testear esta clase específica, decidí crear estos tests porque:
1) Las fichas (Checkers) son componentes fundamentales del juego de backgammon y su correcto funcionamiento es crítico para todo el sistema

2) Al programar los tests descubrí algunos comportamientos que podrían generar bugs más adelante (como el manejo de estados entre captured y bearing_off)

3) Según vimos en clase, una buena cobertura de tests nos ayuda a refactorizar con confianza más adelante

4) Estos tests me ayudaron a entender mejor la responsabilidad de esta clase dentro del sistema

Los tests verifican la inicialización, estados de captura, bearing off y las transiciones entre estados. Me pareció importante asegurar que el player_id sea inmutable después de la creación.

Si creen que estos tests no son necesarios o se pueden simplificar, estoy abierto a feedback. 
 y disculpe las molestias yo en slack le habia escrito si podia mandar un commit despues de las 12 por unos problemas yo hace rato mande el commit y ahora otro que cumpliria con el minimo de 6 commits,el cual no mande despues de las 12 por que no sabia si usted lo iba aceptar y al otro dia me dijo que si espero su respuesta si valen estos dos commits